### PR TITLE
Execute `knob_command`/mute only after button has been released.

### DIFF
--- a/main.c
+++ b/main.c
@@ -175,10 +175,6 @@ int poll_func(struct pollfd *ufds, unsigned long nfds, int timeout, void *userda
   if (knob_depressed && ret == 0) {
     // timer ran out
     knob_depressed = 0;
-    // if muted, and we muted it when depressing the knob in the first place, then unmute
-    if (muted && knob_command == NULL) {
-      pa_context_set_sink_mute_by_index(context, sink_index, !muted, NULL, NULL);
-    }
     if (long_press_command == NULL) {
       movie_mode = !movie_mode;
       printf("Movie mode: %d\n", movie_mode);
@@ -237,16 +233,16 @@ int poll_func(struct pollfd *ufds, unsigned long nfds, int timeout, void *userda
           // knob depressed
           knob_depressed = 1;
           knob_depressed_timestamp = ev.time;
+        }
+        else if (ev.value == 0 && knob_depressed == 1) {
+          // knob released
+          knob_depressed = 0;
           if (knob_command == NULL) {
             pa_context_set_sink_mute_by_index(context, sink_index, !muted, NULL, NULL);
           }
           else {
             exec_command(knob_command);
           }
-        }
-        else if (ev.value == 0) {
-          // knob released
-          knob_depressed = 0;
         }
       }
     }

--- a/main.c
+++ b/main.c
@@ -234,7 +234,7 @@ int poll_func(struct pollfd *ufds, unsigned long nfds, int timeout, void *userda
           knob_depressed = 1;
           knob_depressed_timestamp = ev.time;
         }
-        else if (ev.value == 0 && knob_depressed == 1) {
+        else if (ev.value == 0 && knob_depressed) {
           // knob released
           knob_depressed = 0;
           if (knob_command == NULL) {


### PR DESCRIPTION
This prevents executing `knob_command` or muting when `long_press_command` or movie mode was intended. Without this, the audio would be interrupted for a short while.
I think it's still appropriate to execute the long press action when `long_press_ms` elapsed without waiting for a release event.