### PR TITLE
Add config as a command-line argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,4 @@ You can use `./powermate -d` to daemonize the program without having to update t
 
 By default, the program changes the volume when you turn the knob clockwise and counter clockwise, but you are able to customize the program to do anything via [the configuration file](powermate.toml).
 
-On startup, it tries to read `/etc/powermate.toml` and `$HOME/.powermate.toml` as config files, but you can specify another location with the `-c` option.
-
 Press the knob to mute. Hold down the knob for one second to activate "movie mode". Operation is the same except the LED stays off.

--- a/README.md
+++ b/README.md
@@ -55,4 +55,6 @@ You can use `./powermate -d` to daemonize the program without having to update t
 
 By default, the program changes the volume when you turn the knob clockwise and counter clockwise, but you are able to customize the program to do anything via [the configuration file](powermate.toml).
 
+On startup, it tries to read `/etc/powermate.toml` and `$HOME/.powermate.toml` as config files, but you can specify another location with the `-c` option.
+
 Press the knob to mute. Hold down the knob for one second to activate "movie mode". Operation is the same except the LED stays off.

--- a/main.c
+++ b/main.c
@@ -276,8 +276,8 @@ int main(int argc, char *argv[]) {
   {
     char config_path[PATH_MAX] = "";
     for (i=1; i < argc; i++) {
-      if (!strcmp(argv[i], "-c") && ++i < argc) {
-        strcpy(config_path, argv[i]);
+      if (!strcmp(argv[i], "-c")) {
+        strcpy(config_path, argv[++i]);
         if (access(config_path, R_OK) != 0) {
           fprintf(stderr, "Could not access %s: %s\n", config_path, strerror(errno));
           return 1;

--- a/main.c
+++ b/main.c
@@ -261,7 +261,10 @@ int poll_func(struct pollfd *ufds, unsigned long nfds, int timeout, void *userda
 int main(int argc, char *argv[]) {
   int i;
   for (i=1; i < argc; i++) {
-    if (!strcmp(argv[i],"-h") || !strcmp(argv[i],"--help")) {
+    if (!strcmp(argv[i],"-h") || !strcmp(argv[i],"--help") // check if -h or --help was passed
+     || (strcmp(argv[i],"-c") && strcmp(argv[i],"-d"))     // or if it's an unexpected option
+     || (!strcmp(argv[i],"-c") && ++i == argc)             // or if it's -c but the filename is missing
+    ) {
       fprintf(stderr, "Usage: %s [-c file] [-d]\n", argv[0]);
       return 0;
     }

--- a/main.c
+++ b/main.c
@@ -261,9 +261,8 @@ int poll_func(struct pollfd *ufds, unsigned long nfds, int timeout, void *userda
 int main(int argc, char *argv[]) {
   int i;
   for (i=1; i < argc; i++) {
-    if (!strcmp(argv[i],"-h") || !strcmp(argv[i],"--help") // check if -h or --help was passed
-     || (strcmp(argv[i],"-c") && strcmp(argv[i],"-d"))     // or if it's an unexpected option
-     || (!strcmp(argv[i],"-c") && ++i == argc)             // or if it's -c but the filename is missing
+    if ((strcmp(argv[i],"-c") && strcmp(argv[i],"-d"))     // check if it's an unexpected option
+     || (!strcmp(argv[i],"-c") && ++i == argc)             // check if it's -c but the filename is missing
     ) {
       fprintf(stderr, "Usage: %s [-c file] [-d]\n", argv[0]);
       return 0;

--- a/powermate.toml
+++ b/powermate.toml
@@ -1,6 +1,7 @@
 # The program checks for configuration files in the following order:
 # - $HOME/.powermate.toml
 # - /etc/powermate.toml
+# You can override this and use a custom path by starting the program with the "-c" option.
 # If a file cannot be found, the defaults settings correspond to the values in this file.
 
 # Path to device:


### PR DESCRIPTION
I added this to be able to control multiple PowerMates. Now I can launch one instance with a different configuration for each PowerMate. It's not the most elegant solution, but it works.