### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Binaries are available [in the releases section](https://github.com/stefansundin
 ## Clone Repository
 
 ```bash
-$ git clone https://github.com/stefansundin/powermate-linux.git
+$ git clone --recursive-submodules https://github.com/stefansundin/powermate-linux.git
 $ cd powermate-linux
 ```
 

--- a/main.c
+++ b/main.c
@@ -283,6 +283,12 @@ int main(int argc, char *argv[]) {
 
     char *homedir = getenv("HOME");
     if (config_path[0] == '\0' && homedir != NULL) {
+      sprintf(config_path, "%s/.config/powermate.toml", homedir);
+      if (access(config_path, R_OK) != 0) {
+        config_path[0] = '\0';
+      }
+    }
+    if (config_path[0] == '\0' && homedir != NULL) {
       sprintf(config_path, "%s/.powermate.toml", homedir);
       if (access(config_path, R_OK) != 0) {
         config_path[0] = '\0';

--- a/powermate.toml
+++ b/powermate.toml
@@ -1,4 +1,5 @@
 # The program checks for configuration files in the following order:
+# - $HOME/.config/powermate.toml
 # - $HOME/.powermate.toml
 # - /etc/powermate.toml
 # You can override this and use a custom path by starting the program with the "-c" option.


### PR DESCRIPTION
The recursive git repositories are not cloned with the current build
instructions and lead to the following error:

    gcc -o powermate main.c tomlc99/toml.c -O2 -s -Wall -Wl,--as-needed -D_REENTRANT -lpulse
    gcc: error: tomlc99/toml.c: Datei oder Verzeichnis nicht gefunden

(or the non-localized version of that)

Cloning with --recurse-submodules fixes that.

Also, thank you very much for writing and maintaining this code. This allows me to revive my USB Griffin Powermate and use it as a volume knob once again.